### PR TITLE
ENH: Specify version of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-google-auth
-google-auth-oauthlib
-google-api-python-client
+google-auth>=2.9.1
+google-auth-oauthlib>=0.5.2
+google-api-python-client>=2.52.0
 
 # For test
 mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = tlab_google
+name = tlab-google
 version = attr: tlab_google.__version__
 author = Shuhei Nitta
 author_email = huisintheta@gmail.com
@@ -16,9 +16,9 @@ include_package_data = True
 packages = find:
 test_suite = tests
 install_requires = 
-    google-auth
-    google-auth-oauthlib
-    google-api-python-client
+    google-auth>=2.9.1
+    google-auth-oauthlib>=0.5.2
+    google-api-python-client>=2.52.0
 entry_points = file: entry_points.cfg
 
 [options.packages.find]


### PR DESCRIPTION
Specify version of requirements.

- google-auth >= 2.9.1
- google-auth-oauthlib >= 0.5.2
- google-api-python-client >= 2.52.0